### PR TITLE
Using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: xenial
+language: python
+addons:
+  apt: 
+    packages:
+      - libmysqlclient-dev
+
+python:
+  - "2.7"
+
+install:
+  - pip install .
+
+script: gryphon-runtests

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 
 -----------------
 
-
-| **`Documentation`** |
-|-----------------|
-| [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://gryphon.readthedocs.io/en/latest/) |
-| [![Documentation Status](https://readthedocs.org/projects/gryphon/badge/?version=latest)](https://gryphon.readthedocs.io/en/latest/?badge=latest) |
+| **`Documentation`** | **`Build`** |
+|---------|--------|
+| [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://gryphon.readthedocs.io/en/latest/) | [![Build Status](https://travis-ci.com/TinkerWork/gryphon.svg?branch=master)](https://travis-ci.com/TinkerWork/gryphon) |
+| [![Documentation Status](https://readthedocs.org/projects/gryphon/badge/?version=latest)](https://gryphon.readthedocs.io/en/latest/?badge=latest) |  |
 
 ## What's included
 

--- a/gryphon/tests/logic/configuration/strategy_config_test.py
+++ b/gryphon/tests/logic/configuration/strategy_config_test.py
@@ -44,3 +44,6 @@ class TestSimpleStrategy(unittest.TestCase):
 
         assert strat.spread == Decimal('1')
         assert strat.base_volume == Money('1', 'BTC')
+
+    def tests_failure(self):
+        assert True == False

--- a/gryphon/tests/logic/configuration/strategy_config_test.py
+++ b/gryphon/tests/logic/configuration/strategy_config_test.py
@@ -45,5 +45,3 @@ class TestSimpleStrategy(unittest.TestCase):
         assert strat.spread == Decimal('1')
         assert strat.base_volume == Money('1', 'BTC')
 
-    def tests_failure(self):
-        assert True == False

--- a/gryphon/tests/logic/configuration/strategy_config_test.py
+++ b/gryphon/tests/logic/configuration/strategy_config_test.py
@@ -3,24 +3,31 @@ Just a few exercises for our configuration library.
 """
 import pyximport; pyximport.install()
 import unittest
+import mock
 
 from cdecimal import Decimal
 
 from gryphon.lib.money import Money
-from gryphon.execution.strategies.builtin.improved_market_making import ImprovedMarketMaking
+from gryphon.execution.strategies.builtin.simple_market_making import SimpleMarketMaking
 
 
 class TestSimpleStrategy(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestSimpleStrategy, self).__init__(*args, **kwargs)
+
+        self.mock_harness = mock.Mock()
+        self.mock_harness.exchange_from_key = mock.Mock()
+
     def test_empty_config(self):
         configuration = {
             'platform': {},
             'strategy': {},
             'exchanges': {},
         }
-      
-        strat = ImprovedMarketMaking(None, None, configuration['strategy'])
 
-        assert strat.spread == Decimal('0.10')
+        strat = SimpleMarketMaking(None, self.mock_harness, configuration['strategy'])
+
+        assert strat.spread == Decimal('0.01')
         assert strat.base_volume == Money('0.005', 'BTC')
 
     def test_simple(self):
@@ -33,7 +40,7 @@ class TestSimpleStrategy(unittest.TestCase):
             'exchanges': {},
         }
       
-        strat = ImprovedMarketMaking(None, None, configuration['strategy'])
+        strat = SimpleMarketMaking(None, self.mock_harness, configuration['strategy'])
 
         assert strat.spread == Decimal('1')
         assert strat.base_volume == Money('1', 'BTC')

--- a/gryphon/tests/runtests.py
+++ b/gryphon/tests/runtests.py
@@ -29,3 +29,5 @@ def main():
     ]
 
     nose.run(argv=args)
+
+    sys.exit(1)

--- a/gryphon/tests/runtests.py
+++ b/gryphon/tests/runtests.py
@@ -28,6 +28,9 @@ def main():
         '--where=%s' % test_dir,
     ]
 
-    nose.run(argv=args)
+    result = nose.run(argv=args)
 
-    sys.exit(1)
+    if result is True:
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
We now use travis ci for unit testing.

This includes fixing one unit test that was failing due to the recent builtin-strategy changes.