### PR TITLE
Add editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{py, pyx, md, rst}]
+indent_size = 4


### PR DESCRIPTION
Add support for cross-platform editor configuration.
https://editorconfig.org/

The addition of this config file has no effect for anyone not using editorconfig. However, for those with the relevant plugin installed for their editor/ide of choice, it defines a consistent configuration for the project.